### PR TITLE
HOTFIX: TLS mode might be a string

### DIFF
--- a/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentServices.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentServices.tpl
@@ -1,6 +1,6 @@
 {{- define "hotelreservation.templates.baseDeploymentServices" }}
 {{ $fullname := include "hotel-reservation.fullname" . }}
-{{- if and (hasKey $.Values "tlsCertificates") (eq $.Values.global.services.environments.TLS 1) }}
+{{- if and (hasKey $.Values "tlsCertificates") (eq (toString $.Values.global.services.environments.TLS) "1") }}
 {{- range $secret := $.Values.tlsCertificates }}
 apiVersion: v1
 kind: Secret
@@ -116,7 +116,7 @@ spec:
         resources:
           {{ tpl $.Values.global.resources $ | nindent 10 | trim }}
         {{- end }}
-        {{- if or (hasKey $.Values "configMaps") (and (hasKey $.Values "tlsCertificates") (eq $.Values.global.services.environments.TLS 1)) }}
+        {{- if or (hasKey $.Values "configMaps") (and (hasKey $.Values "tlsCertificates") (eq (toString $.Values.global.services.environments.TLS) "1")) }}
         volumeMounts: 
         {{- if $.Values.configMaps }} 
         {{- range $configMap := $.Values.configMaps }}
@@ -125,7 +125,7 @@ spec:
           subPath: {{ $configMap.name }}
         {{- end }}
         {{- end }}
-        {{- if and (hasKey $.Values "tlsCertificates") (eq $.Values.global.services.environments.TLS 1) }}
+        {{- if and (hasKey $.Values "tlsCertificates") (eq (toString $.Values.global.services.environments.TLS) "1") }}
         {{- range $secret := $.Values.tlsCertificates }}
         - name: {{ $secret.name | quote }}
           readOnly: true
@@ -134,14 +134,14 @@ spec:
         {{- end }}
         {{- end }}
       {{- end -}}
-      {{- if or (hasKey $.Values "configMaps") (and (hasKey $.Values "tlsCertificates") (eq $.Values.global.services.environments.TLS 1)) }}
+      {{- if or (hasKey $.Values "configMaps") (and (hasKey $.Values "tlsCertificates") (eq (toString $.Values.global.services.environments.TLS) "1")) }}
       volumes:
       {{- if $.Values.configMaps }}
       - name: {{ $.Values.name }}-{{ include "hotel-reservation.fullname" $ }}-config
         configMap:
           name: {{ $.Values.name }}-{{ include "hotel-reservation.fullname" $ }}
       {{- end }}
-      {{- if and (hasKey $.Values "tlsCertificates") (eq $.Values.global.services.environments.TLS 1) }}
+      {{- if and (hasKey $.Values "tlsCertificates") (eq (toString $.Values.global.services.environments.TLS) "1") }}
       {{- range $secret := $.Values.tlsCertificates }}
       - name: {{ $secret.name | quote }}
         secret:

--- a/hotelReservation/helm-chart/hotelreservation/templates/wrk2_deployment.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/wrk2_deployment.tpl
@@ -1,6 +1,6 @@
 {{- define "hotelreservation.templates.wrk2-deployment" }}
 {{ $fullname := include "hotel-reservation.fullname" . }}
-{{- if eq $.Values.global.services.environments.TLS 1 }}
+{{- if eq (toString $.Values.global.services.environments.TLS) "1" }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: wrk2
           image: "saurabhjha1/hotelreswrk2:latest"
-          {{- if eq $.Values.global.services.environments.TLS 1 }}
+          {{- if eq (toString $.Values.global.services.environments.TLS) "1" }}
           volumeMounts: 
           - name: "ca-certificate"
             readOnly: true
@@ -37,7 +37,7 @@ spec:
             - "/bin/sh"
             - "-c"
             - |
-              {{- if eq $.Values.global.services.environments.TLS 1 }}
+              {{- if eq (toString $.Values.global.services.environments.TLS) "1" }}
               cp -r certificates /usr/share/ca-certificates/custom-ca
               echo custom-ca/ca_cert.pem >> /etc/ca-certificates.conf
               update-ca-certificates
@@ -63,14 +63,14 @@ spec:
             - name: WRK2_REQUESTS_PER_SEC
               value: "{{ $.Values.loadgen.requestsPerSec }}"
             - name: WRK2_TARGET_URL
-              {{- if eq $.Values.global.services.environments.TLS 1 }}
+              {{- if eq (toString $.Values.global.services.environments.TLS) "1" }}
               value: "https://frontend-{{ include "hotel-reservation.fullname" . }}.{{ .Release.Namespace }}.svc.{{ $.Values.global.serviceDnsDomain }}:5000"
               {{- else }}
               value: "http://frontend-{{ include "hotel-reservation.fullname" . }}.{{ .Release.Namespace }}.svc.{{ $.Values.global.serviceDnsDomain }}:5000"
               {{- end }}
             - name: WRK2_SCRIPT_PATH
               value: "{{ $.Values.loadgen.scriptPath }}"
-      {{- if eq $.Values.global.services.environments.TLS 1 }}
+      {{- if eq (toString $.Values.global.services.environments.TLS) "1" }}
       volumes:
       - name: "ca-certificate"
         secret:


### PR DESCRIPTION
The TLS mode should usually be 0 or 1, but it is permitted to have a string value to use a custom cypher suite

https://github.com/delimitrou/DeathStarBench/blob/6ecb09706140f8730b5385c08f1386c654c3c526/hotelReservation/helm-chart/hotelreservation/values.yaml#L13-L18

The helm charts for installing certificates were comparing the setting to `1`, which would cause a failure if it had a string value.

@Red-GV and @JacksonArthurClark this may address the bug that you found:

```
fatal: [localhost]: FAILED! => {"changed": false, "command": "/opt/homebrew/bin/helm upgrade -i --reset-values --create-namespace --set global.monitoring.otelAddress=otel-collector-hotel-reservations.hotel-reservations.svc.cluster.local --set global.monitoring.defaultJaegerEnabled=false --set global.monitoring.centralJaegerAddress=jaeger-collector.jaeger.svc.cluster.local --set global.monitoring.centralPrometheusAddress=http://prometheus-stack-kube-prom-prometheus.prometheus:9090/api/v1/otlp --set global.nameOverride=hotel-reservations hotel-reservations 'roles/sample_applications/DeathStarBench/hotelReservation/helm-chart/hotelreservation'", "msg": "Failure when executing Helm command. Exited 1.\nstdout: Release \"hotel-reservations\" does not exist. Installing it now.\n\nstderr: Error: template: hotel-reservation/charts/wrk2/templates/deployment.yaml:1:3: executing \"hotel-reservation/charts/wrk2/templates/deployment.yaml\" at <include \"hotelreservation.templates.wrk2-deployment\" .>: error calling include: template: hotel-reservation/templates/wrk2_deployment.tpl:3:7: executing \"hotelreservation.templates.wrk2-deployment\" at <eq $.Values.global.services.environments.TLS 1>: error calling eq: incompatible types for comparison\n", "stderr": "Error: template: hotel-reservation/charts/wrk2/templates/deployment.yaml:1:3: executing \"hotel-reservation/charts/wrk2/templates/deployment.yaml\" at <include \"hotelreservation.templates.wrk2-deployment\" .>: error calling include: template: hotel-reservation/templates/wrk2_deployment.tpl:3:7: executing \"hotelreservation.templates.wrk2-deployment\" at <eq $.Values.global.services.environments.TLS 1>: error calling eq: incompatible types for comparison\n", "stderr_lines": ["Error: template: hotel-reservation/charts/wrk2/templates/deployment.yaml:1:3: executing \"hotel-reservation/charts/wrk2/templates/deployment.yaml\" at <include \"hotelreservation.templates.wrk2-deployment\" .>: error calling include: template: hotel-reservation/templates/wrk2_deployment.tpl:3:7: executing \"hotelreservation.templates.wrk2-deployment\" at <eq $.Values.global.services.environments.TLS 1>: error calling eq: incompatible types for comparison"], "stdout": "Release \"hotel-reservations\" does not exist. Installing it now.\n", "stdout_lines": ["Release \"hotel-reservations\" does not exist. Installing it now."]}
```
Specifically this bit: `at <eq $.Values.global.services.environments.TLS 1>: error calling eq: incompatible types for comparison` sounds like this is the problem.

Does this make sense in your environment?  Are you setting TLS to a string?